### PR TITLE
fix: remove semantic-release git plugin for protected branch compatibility

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,8 +4,6 @@
   "plugins": [
     ["@semantic-release/commit-analyzer", {"preset": "angular"}],
     ["@semantic-release/release-notes-generator", {"preset": "angular"}],
-    ["@semantic-release/changelog", {"changelogFile": "CHANGELOG.md"}],
-    ["@semantic-release/github", {"assets": ["dist/**/*.{go,mod,sum}", "docs/**/*.{pdf,md}"]}],
-    ["@semantic-release/git", {"assets": ["CHANGELOG.md", "go.mod", "go.sum"], "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"}]
+    ["@semantic-release/github", {"assets": ["dist/**/*.{go,mod,sum}", "docs/**/*.{pdf,md}"]}]
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/changelog` and `@semantic-release/git` plugins from `.releaserc`
- These plugins try to push CHANGELOG.md directly to `main`, which fails with branch protection (`GH006: Protected branch update failed`)
- Release notes are still generated and attached to the GitHub Release by `@semantic-release/release-notes-generator` and `@semantic-release/github`

## Test plan
- [ ] Merge this PR and verify the release workflow creates a `v1.0.0` tag and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)