### PR TITLE
fix: add GoReleaser config for linux/darwin builds only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: homerun2-k8s-pitcher
+    main: .
+    binary: homerun2-k8s-pitcher
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -extldflags=-static
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: stuttgart-things
+    name: homerun2-k8s-pitcher
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` matching the omni-pitcher config style
- Build only for linux/darwin (amd64 + arm64), no windows
- Fixes GoReleaser step failure in the release workflow

## Test plan
- [ ] Merge and verify release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)