### PR TITLE
feat: add Flux notification webhook endpoint

### DIFF
--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -18,8 +18,15 @@ type Spec struct {
 	Redis      RedisConfig     `yaml:"redis"`
 	Pitcher    PitcherConfig   `yaml:"pitcher"`
 	Auth       AuthConfig      `yaml:"auth"`
+	Webhook    WebhookConfig   `yaml:"webhook"`
 	Collectors []CollectorSpec `yaml:"collectors"`
 	Informers  []InformerSpec  `yaml:"informers"`
+}
+
+type WebhookConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Port    string `yaml:"port"`
+	HMACKey string `yaml:"hmacKey"`
 }
 
 type PitcherConfig struct {

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,204 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/pitcher"
+)
+
+// FluxEvent represents the JSON payload sent by the Flux notification controller
+// generic webhook provider.
+type FluxEvent struct {
+	InvolvedObject InvolvedObject `json:"involvedObject"`
+	Severity       string         `json:"severity"`
+	Timestamp      string         `json:"timestamp"`
+	Message        string         `json:"message"`
+	Reason         string         `json:"reason"`
+	Controller     string         `json:"reportingController"`
+	Instance       string         `json:"reportingInstance"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+// InvolvedObject identifies the Flux resource that triggered the event.
+type InvolvedObject struct {
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	UID             string `json:"uid"`
+	APIVersion      string `json:"apiVersion"`
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+// Server handles incoming Flux notification webhook requests.
+type Server struct {
+	pitcher    pitcher.K8sPitcher
+	cluster    string
+	hmacKey    []byte // optional HMAC key for signature verification
+}
+
+// NewServer creates a webhook server that pitches Flux events.
+func NewServer(p pitcher.K8sPitcher, clusterName string, hmacKey string) *Server {
+	s := &Server{
+		pitcher: p,
+		cluster: clusterName,
+	}
+	if hmacKey != "" {
+		s.hmacKey = []byte(hmacKey)
+	}
+	return s
+}
+
+// Handler returns an http.Handler with the webhook routes.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /flux", s.handleFlux)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	return mux
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *Server) handleFlux(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	// Verify HMAC signature if key is configured
+	if s.hmacKey != nil {
+		sig := r.Header.Get("X-Signature")
+		if sig == "" {
+			http.Error(w, "missing X-Signature header", http.StatusUnauthorized)
+			return
+		}
+		if err := verifySignature(sig, body, s.hmacKey); err != nil {
+			slog.Warn("flux webhook HMAC verification failed", "error", err)
+			http.Error(w, "signature verification failed", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	var event FluxEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	k8sEvent := fluxEventToK8sEvent(event, s.cluster, r.Header.Get("Gotk-Component"))
+
+	if err := s.pitcher.Pitch(k8sEvent); err != nil {
+		slog.Error("failed to pitch flux event",
+			"kind", event.InvolvedObject.Kind,
+			"name", event.InvolvedObject.Name,
+			"error", err,
+		)
+		http.Error(w, "failed to pitch event", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("flux event pitched",
+		"kind", event.InvolvedObject.Kind,
+		"name", event.InvolvedObject.Name,
+		"severity", event.Severity,
+		"reason", event.Reason,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"accepted"}`))
+}
+
+func fluxEventToK8sEvent(event FluxEvent, cluster, component string) pitcher.K8sEvent {
+	summary := summarizeFluxEvent(event, component)
+
+	ts := event.Timestamp
+	if ts == "" {
+		ts = time.Now().Format(time.RFC3339)
+	}
+
+	return pitcher.K8sEvent{
+		Kind:      fmt.Sprintf("Flux/%s", event.InvolvedObject.Kind),
+		EventType: event.Reason,
+		Namespace: event.InvolvedObject.Namespace,
+		Name:      event.InvolvedObject.Name,
+		Summary:   summary,
+		Timestamp: ts,
+		Cluster:   cluster,
+	}
+}
+
+func summarizeFluxEvent(event FluxEvent, component string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s %s/%s\n", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
+	fmt.Fprintf(&b, "Severity: %s\n", event.Severity)
+	fmt.Fprintf(&b, "Reason: %s\n", event.Reason)
+	fmt.Fprintf(&b, "Message: %s\n", event.Message)
+
+	if component != "" {
+		fmt.Fprintf(&b, "Controller: %s\n", component)
+	} else if event.Controller != "" {
+		fmt.Fprintf(&b, "Controller: %s\n", event.Controller)
+	}
+
+	if event.InvolvedObject.APIVersion != "" {
+		fmt.Fprintf(&b, "API: %s\n", event.InvolvedObject.APIVersion)
+	}
+
+	// Include metadata (e.g., revision info)
+	for k, v := range event.Metadata {
+		fmt.Fprintf(&b, "%s: %s\n", k, v)
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+// verifySignature verifies the HMAC signature from the X-Signature header.
+// Format: HASH_FUNC=HASH (e.g., sha256=abc123...)
+func verifySignature(sig string, payload, key []byte) error {
+	parts := strings.SplitN(sig, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid signature format")
+	}
+
+	var newF func() hash.Hash
+	switch parts[0] {
+	case "sha224":
+		newF = sha256.New224
+	case "sha256":
+		newF = sha256.New
+	case "sha384":
+		newF = sha512.New384
+	case "sha512":
+		newF = sha512.New
+	default:
+		return fmt.Errorf("unsupported hash algorithm %q", parts[0])
+	}
+
+	mac := hmac.New(newF, key)
+	if _, err := mac.Write(payload); err != nil {
+		return fmt.Errorf("computing HMAC: %w", err)
+	}
+
+	expected := fmt.Sprintf("%x", mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(parts[1])) {
+		return fmt.Errorf("signature mismatch")
+	}
+	return nil
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,254 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/pitcher"
+)
+
+// mockPitcher captures pitched events for testing.
+type mockPitcher struct {
+	mu     sync.Mutex
+	events []pitcher.K8sEvent
+}
+
+func (m *mockPitcher) Pitch(event pitcher.K8sEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+	return nil
+}
+
+func (m *mockPitcher) HealthCheck(_ context.Context) error {
+	return nil
+}
+
+func (m *mockPitcher) lastEvent() pitcher.K8sEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.events[len(m.events)-1]
+}
+
+func TestHandleFlux(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "")
+	handler := srv.Handler()
+
+	event := FluxEvent{
+		InvolvedObject: InvolvedObject{
+			Kind:       "Kustomization",
+			Namespace:  "flux-system",
+			Name:       "my-app",
+			APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+		},
+		Severity:   "info",
+		Timestamp:  "2026-03-10T12:00:00Z",
+		Message:    "Applied revision: main/abc123",
+		Reason:     "ReconciliationSucceeded",
+		Controller: "kustomize-controller",
+	}
+
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest("POST", "/flux", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Gotk-Component", "kustomize-controller")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got := mock.lastEvent()
+	if got.Kind != "Flux/Kustomization" {
+		t.Errorf("expected Kind 'Flux/Kustomization', got %q", got.Kind)
+	}
+	if got.EventType != "ReconciliationSucceeded" {
+		t.Errorf("expected EventType 'ReconciliationSucceeded', got %q", got.EventType)
+	}
+	if got.Namespace != "flux-system" {
+		t.Errorf("expected Namespace 'flux-system', got %q", got.Namespace)
+	}
+	if got.Name != "my-app" {
+		t.Errorf("expected Name 'my-app', got %q", got.Name)
+	}
+	if got.Cluster != "test-cluster" {
+		t.Errorf("expected Cluster 'test-cluster', got %q", got.Cluster)
+	}
+	if !strings.Contains(got.Summary, "Kustomization flux-system/my-app") {
+		t.Errorf("summary should contain resource info, got %q", got.Summary)
+	}
+	if !strings.Contains(got.Summary, "Applied revision: main/abc123") {
+		t.Errorf("summary should contain message, got %q", got.Summary)
+	}
+	if !strings.Contains(got.Summary, "kustomize-controller") {
+		t.Errorf("summary should contain controller, got %q", got.Summary)
+	}
+}
+
+func TestHandleFlux_InvalidJSON(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "")
+	handler := srv.Handler()
+
+	req := httptest.NewRequest("POST", "/flux", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleFlux_HMAC(t *testing.T) {
+	key := "test-secret-key"
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", key)
+	handler := srv.Handler()
+
+	event := FluxEvent{
+		InvolvedObject: InvolvedObject{
+			Kind:      "GitRepository",
+			Namespace: "flux-system",
+			Name:      "flux-system",
+		},
+		Severity: "info",
+		Message:  "Fetched revision: main/abc123",
+		Reason:   "info",
+	}
+
+	body, _ := json.Marshal(event)
+
+	// Compute valid HMAC
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write(body)
+	sig := fmt.Sprintf("sha256=%x", mac.Sum(nil))
+
+	req := httptest.NewRequest("POST", "/flux", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Signature", sig)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with valid HMAC, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleFlux_HMAC_Missing(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "my-key")
+	handler := srv.Handler()
+
+	body := []byte(`{"message":"test"}`)
+	req := httptest.NewRequest("POST", "/flux", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without signature, got %d", rec.Code)
+	}
+}
+
+func TestHandleFlux_HMAC_Invalid(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "my-key")
+	handler := srv.Handler()
+
+	body := []byte(`{"message":"test"}`)
+	req := httptest.NewRequest("POST", "/flux", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Signature", "sha256=badhash")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with bad signature, got %d", rec.Code)
+	}
+}
+
+func TestHandleHealthz(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "")
+	handler := srv.Handler()
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	key := []byte("secret")
+	payload := []byte("hello world")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payload)
+	sig := fmt.Sprintf("sha256=%x", mac.Sum(nil))
+
+	if err := verifySignature(sig, payload, key); err != nil {
+		t.Fatalf("expected valid signature, got error: %v", err)
+	}
+
+	if err := verifySignature("sha256=wrong", payload, key); err == nil {
+		t.Fatal("expected error for wrong signature")
+	}
+
+	if err := verifySignature("invalid", payload, key); err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+}
+
+func TestSummarizeFluxEvent(t *testing.T) {
+	event := FluxEvent{
+		InvolvedObject: InvolvedObject{
+			Kind:       "HelmRelease",
+			Namespace:  "apps",
+			Name:       "redis",
+			APIVersion: "helm.toolkit.fluxcd.io/v2",
+		},
+		Severity:   "error",
+		Message:    "install retries exhausted",
+		Reason:     "InstallFailed",
+		Controller: "helm-controller",
+		Metadata: map[string]string{
+			"helm.toolkit.fluxcd.io/revision": "6.0.0",
+		},
+	}
+
+	summary := summarizeFluxEvent(event, "helm-controller")
+
+	if !strings.Contains(summary, "HelmRelease apps/redis") {
+		t.Errorf("missing resource line: %s", summary)
+	}
+	if !strings.Contains(summary, "Severity: error") {
+		t.Errorf("missing severity: %s", summary)
+	}
+	if !strings.Contains(summary, "Reason: InstallFailed") {
+		t.Errorf("missing reason: %s", summary)
+	}
+	if !strings.Contains(summary, "install retries exhausted") {
+		t.Errorf("missing message: %s", summary)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"net/http"
+
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/banner"
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/collector"
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/config"
@@ -17,6 +19,7 @@ import (
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/kube"
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/pitcher"
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/profile"
+	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/webhook"
 )
 
 var (
@@ -127,6 +130,32 @@ func main() {
 		m := informer.New(kubeClient.DynamicClient, p, prof.Spec.Informers, kubeClient.ClusterName)
 		go m.Start(ctx)
 		slog.Info("informers started", "count", len(prof.Spec.Informers))
+	}
+
+	// Start webhook server if enabled
+	if prof.Spec.Webhook.Enabled {
+		port := prof.Spec.Webhook.Port
+		if port == "" {
+			port = "8080"
+		}
+		ws := webhook.NewServer(p, kubeClient.ClusterName, prof.Spec.Webhook.HMACKey)
+		srv := &http.Server{
+			Addr:              ":" + port,
+			Handler:           ws.Handler(),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			slog.Info("webhook server started", "port", port)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("webhook server error", "error", err)
+			}
+		}()
+		go func() {
+			<-ctx.Done()
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutdownCancel()
+			_ = srv.Shutdown(shutdownCtx)
+		}()
 	}
 
 	slog.Info("homerun2-k8s-pitcher running", "cluster", kubeClient.ClusterName)


### PR DESCRIPTION
## Summary
- Add HTTP webhook server (`POST /flux`) that accepts Flux notification controller generic webhook events
- Maps Flux events to K8sEvent with human-readable summaries and pitches them through the existing pitcher pipeline
- Supports optional HMAC signature verification (`X-Signature` header) for `generic-hmac` provider type
- Configurable via profile YAML: `webhook.enabled`, `webhook.port`, `webhook.hmacKey`
- Health check endpoint at `GET /healthz`

## Flux Integration

```yaml
# On any Flux cluster, create a Provider + Alert to send events to k8s-pitcher:
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Provider
metadata:
  name: homerun2
spec:
  type: generic
  address: http://homerun2-k8s-pitcher.homerun2-flux.svc.cluster.local:8080/flux
---
apiVersion: notification.toolkit.fluxcd.io/v1beta3
kind: Alert
metadata:
  name: homerun2
spec:
  providerRef:
    name: homerun2
  eventSeverity: info
  eventSources:
    - kind: Kustomization
      name: "*"
    - kind: HelmRelease
      name: "*"
```

## Profile Config

```yaml
spec:
  webhook:
    enabled: true
    port: "8080"        # optional, default 8080
    hmacKey: ""          # optional, for generic-hmac provider type
```

## Test plan
- [x] 8 unit tests passing (handler, HMAC verification, summary, health check)
- [x] Full test suite passes (`go test ./...`)
- [ ] KCL deployment update needed (containerPort, Service) — follow-up

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)