### PR TITLE
fix(deps): upgrade homerun-library from v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.1
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/stuttgart-things/homerun-library/v2 v2.0.1-0.20260307163657-17be19573fe0
+	github.com/stuttgart-things/homerun-library/v3 v3.0.4
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stuttgart-things/homerun-library/v2 v2.0.1-0.20260307163657-17be19573fe0 h1:N5L5EKyCYq/Xfw8cV4JbJAWQDPakyxRpqBCPadeYfpI=
-github.com/stuttgart-things/homerun-library/v2 v2.0.1-0.20260307163657-17be19573fe0/go.mod h1:aRjTENEjHJTKHe0YOQxUNwKqDT0eVD2PRD2AJMTiKeU=
+github.com/stuttgart-things/homerun-library/v3 v3.0.4 h1:QsuSnE9ui+qLBcwKKsm4Ls6dvqyI87HZy0h3Fcj4J70=
+github.com/stuttgart-things/homerun-library/v3 v3.0.4/go.mod h1:mVBDKcIWeXj+qDiooX0RkS5PpxPZ+JOs5kpPc+jeD9A=
 github.com/stuttgart-things/redisqueue v0.0.0-20230628084515-1d31f7874df7 h1:nVooDvBYhBPQysVjbvWP3S1CQgmNG/Vovt+ahmv9Cas=
 github.com/stuttgart-things/redisqueue v0.0.0-20230628084515-1d31f7874df7/go.mod h1:RhH+7myjNLGs/BFeYO5U7ekmM7OsymsIOUN/DkewR3g=
 github.com/stuttgart-things/sthingsBase v0.1.41 h1:0aRlEqYilwaJAl9lqv17ZxXXtYAwONw4Rk0X/SLJ+BI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	homerun "github.com/stuttgart-things/homerun-library/v2"
+	homerun "github.com/stuttgart-things/homerun-library/v3"
 )
 
 func LoadRedisConfig() homerun.RedisConfig {

--- a/internal/pitcher/pitcher.go
+++ b/internal/pitcher/pitcher.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	homerun "github.com/stuttgart-things/homerun-library/v2"
+	homerun "github.com/stuttgart-things/homerun-library/v3"
 
 	"github.com/stuttgart-things/homerun2-k8s-pitcher/internal/profile"
 )


### PR DESCRIPTION
## Summary
- Upgrades `homerun-library` from v2 (pseudo-version) to v3.0.4
- Module path fix landed in homerun-library v3.0.4 (PR #78)
- No API changes — just module path update from `/v2` to `/v3`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)