### PR TITLE
fix: use Flux event severity and uppercase levels

### DIFF
--- a/internal/pitcher/pitcher.go
+++ b/internal/pitcher/pitcher.go
@@ -27,6 +27,7 @@ type K8sEvent struct {
 	Name      string         `json:"name"`
 	Object    map[string]any `json:"object"`
 	Summary   string         `json:"summary,omitempty"` // human-readable text summary
+	Severity  string         `json:"severity,omitempty"` // override severity (e.g. from Flux events)
 	Timestamp string         `json:"timestamp"`
 	Cluster   string         `json:"cluster"`
 }
@@ -79,10 +80,15 @@ func (p *RedisK8sPitcher) Pitch(event K8sEvent) error {
 		message = string(objectJSON)
 	}
 
+	sev := event.Severity
+	if sev == "" {
+		sev = severityFor(event.EventType)
+	}
+
 	msg := homerun.Message{
 		Title:     fmt.Sprintf("%s/%s %s", event.Kind, event.Name, event.EventType),
 		Message:   message,
-		Severity:  severityFor(event.EventType),
+		Severity:  sev,
 		Author:    "k8s-pitcher",
 		Timestamp: event.Timestamp,
 		System:    p.System,
@@ -107,11 +113,11 @@ func (p *RedisK8sPitcher) Pitch(event K8sEvent) error {
 func severityFor(eventType string) string {
 	switch eventType {
 	case "delete":
-		return "warning"
+		return "WARNING"
 	case "snapshot":
-		return "info"
+		return "INFO"
 	default:
-		return "info"
+		return "INFO"
 	}
 }
 
@@ -137,7 +143,7 @@ func (p *HTTPK8sPitcher) HealthCheck(_ context.Context) error {
 	msg := homerun.Message{
 		Title:     "health-check",
 		Message:   "k8s-pitcher health check",
-		Severity:  "info",
+		Severity:  "INFO",
 		Author:    "k8s-pitcher",
 		Timestamp: time.Now().Format(time.RFC3339),
 		System:    p.System,
@@ -171,10 +177,15 @@ func (p *HTTPK8sPitcher) Pitch(event K8sEvent) error {
 		message = string(objectJSON)
 	}
 
+	sev := event.Severity
+	if sev == "" {
+		sev = severityFor(event.EventType)
+	}
+
 	msg := homerun.Message{
 		Title:     fmt.Sprintf("%s/%s %s", event.Kind, event.Name, event.EventType),
 		Message:   message,
-		Severity:  severityFor(event.EventType),
+		Severity:  sev,
 		Author:    "k8s-pitcher",
 		Timestamp: event.Timestamp,
 		System:    p.System,

--- a/internal/pitcher/pitcher_test.go
+++ b/internal/pitcher/pitcher_test.go
@@ -108,10 +108,10 @@ func TestSeverityFor(t *testing.T) {
 		eventType string
 		want      string
 	}{
-		{"add", "info"},
-		{"update", "info"},
-		{"delete", "warning"},
-		{"snapshot", "info"},
+		{"add", "INFO"},
+		{"update", "INFO"},
+		{"delete", "WARNING"},
+		{"snapshot", "INFO"},
 	}
 	for _, tt := range tests {
 		got := severityFor(tt.eventType)
@@ -206,7 +206,7 @@ func TestHTTPK8sPitcherPitch(t *testing.T) {
 	}
 
 	body := string(gotBody)
-	for _, want := range []string{`"author":"k8s-pitcher"`, `"system":"test-cluster"`, `"severity":"info"`} {
+	for _, want := range []string{`"author":"k8s-pitcher"`, `"system":"test-cluster"`, `"severity":"INFO"`} {
 		if !contains(body, want) {
 			t.Errorf("body missing %q\nbody: %s", want, body)
 		}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -138,6 +138,7 @@ func fluxEventToK8sEvent(event FluxEvent, cluster, component string) pitcher.K8s
 		Namespace: event.InvolvedObject.Namespace,
 		Name:      event.InvolvedObject.Name,
 		Summary:   summary,
+		Severity:  strings.ToUpper(event.Severity),
 		Timestamp: ts,
 		Cluster:   cluster,
 	}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -95,6 +95,42 @@ func TestHandleFlux(t *testing.T) {
 	if !strings.Contains(got.Summary, "kustomize-controller") {
 		t.Errorf("summary should contain controller, got %q", got.Summary)
 	}
+	if got.Severity != "INFO" {
+		t.Errorf("expected Severity 'INFO', got %q", got.Severity)
+	}
+}
+
+func TestHandleFlux_SeverityPassthrough(t *testing.T) {
+	mock := &mockPitcher{}
+	srv := NewServer(mock, "test-cluster", "")
+	handler := srv.Handler()
+
+	event := FluxEvent{
+		InvolvedObject: InvolvedObject{
+			Kind:      "Kustomization",
+			Namespace: "flux-system",
+			Name:      "my-app",
+		},
+		Severity: "error",
+		Message:  "health check failed",
+		Reason:   "HealthCheckFailed",
+	}
+
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest("POST", "/flux", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	got := mock.lastEvent()
+	if got.Severity != "ERROR" {
+		t.Errorf("expected Severity 'ERROR' (uppercased from Flux event), got %q", got.Severity)
+	}
 }
 
 func TestHandleFlux_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `Severity` field to `K8sEvent` struct for source-provided severity override
- Flux webhook events now pass through their own severity (uppercased) instead of defaulting everything to `info`
- `severityFor()` returns uppercase values: `INFO`, `WARNING`
- `HealthCheckFailed` Flux events now correctly show as `ERROR` in core-catcher

Closes #36

## Test plan
- [x] `go test ./...` passes
- [x] `TestSeverityFor` updated for uppercase values
- [x] `TestHTTPK8sPitcherPitch` updated for uppercase `INFO`
- [x] New `TestHandleFlux_SeverityPassthrough` verifies Flux `error` → `ERROR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)