### PR TITLE
feat: outcome-based severity, subsystem as system field

### DIFF
--- a/internal/pitcher/pitcher.go
+++ b/internal/pitcher/pitcher.go
@@ -26,8 +26,9 @@ type K8sEvent struct {
 	Namespace string         `json:"namespace"`
 	Name      string         `json:"name"`
 	Object    map[string]any `json:"object"`
-	Summary   string         `json:"summary,omitempty"` // human-readable text summary
+	Summary   string         `json:"summary,omitempty"`  // human-readable text summary
 	Severity  string         `json:"severity,omitempty"` // override severity (e.g. from Flux events)
+	Subsystem string         `json:"subsystem,omitempty"` // source subsystem (e.g. "flux", "kubernetes")
 	Timestamp string         `json:"timestamp"`
 	Cluster   string         `json:"cluster"`
 }
@@ -85,13 +86,18 @@ func (p *RedisK8sPitcher) Pitch(event K8sEvent) error {
 		sev = severityFor(event.EventType)
 	}
 
+	subsystem := event.Subsystem
+	if subsystem == "" {
+		subsystem = "kubernetes"
+	}
+
 	msg := homerun.Message{
 		Title:     fmt.Sprintf("%s/%s %s", event.Kind, event.Name, event.EventType),
 		Message:   message,
 		Severity:  sev,
-		Author:    "k8s-pitcher",
+		Author:    "k8s-pitcher-" + p.System,
 		Timestamp: event.Timestamp,
-		System:    p.System,
+		System:    subsystem,
 		Tags:      fmt.Sprintf("k8s,%s,%s,%s", event.Kind, event.EventType, event.Namespace),
 	}
 
@@ -112,10 +118,10 @@ func (p *RedisK8sPitcher) Pitch(event K8sEvent) error {
 
 func severityFor(eventType string) string {
 	switch eventType {
+	case "add", "update":
+		return "SUCCESS"
 	case "delete":
 		return "WARNING"
-	case "snapshot":
-		return "INFO"
 	default:
 		return "INFO"
 	}
@@ -144,9 +150,9 @@ func (p *HTTPK8sPitcher) HealthCheck(_ context.Context) error {
 		Title:     "health-check",
 		Message:   "k8s-pitcher health check",
 		Severity:  "INFO",
-		Author:    "k8s-pitcher",
+		Author:    "k8s-pitcher-" + p.System,
 		Timestamp: time.Now().Format(time.RFC3339),
-		System:    p.System,
+		System:    "kubernetes",
 		Tags:      "health-check",
 	}
 
@@ -182,13 +188,18 @@ func (p *HTTPK8sPitcher) Pitch(event K8sEvent) error {
 		sev = severityFor(event.EventType)
 	}
 
+	subsystem := event.Subsystem
+	if subsystem == "" {
+		subsystem = "kubernetes"
+	}
+
 	msg := homerun.Message{
 		Title:     fmt.Sprintf("%s/%s %s", event.Kind, event.Name, event.EventType),
 		Message:   message,
 		Severity:  sev,
-		Author:    "k8s-pitcher",
+		Author:    "k8s-pitcher-" + p.System,
 		Timestamp: event.Timestamp,
-		System:    p.System,
+		System:    subsystem,
 		Tags:      fmt.Sprintf("k8s,%s,%s,%s", event.Kind, event.EventType, event.Namespace),
 	}
 

--- a/internal/pitcher/pitcher_test.go
+++ b/internal/pitcher/pitcher_test.go
@@ -108,8 +108,8 @@ func TestSeverityFor(t *testing.T) {
 		eventType string
 		want      string
 	}{
-		{"add", "INFO"},
-		{"update", "INFO"},
+		{"add", "SUCCESS"},
+		{"update", "SUCCESS"},
 		{"delete", "WARNING"},
 		{"snapshot", "INFO"},
 	}
@@ -206,7 +206,7 @@ func TestHTTPK8sPitcherPitch(t *testing.T) {
 	}
 
 	body := string(gotBody)
-	for _, want := range []string{`"author":"k8s-pitcher"`, `"system":"test-cluster"`, `"severity":"INFO"`} {
+	for _, want := range []string{`"author":"k8s-pitcher-test-cluster"`, `"system":"kubernetes"`, `"severity":"SUCCESS"`} {
 		if !contains(body, want) {
 			t.Errorf("body missing %q\nbody: %s", want, body)
 		}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -138,9 +138,23 @@ func fluxEventToK8sEvent(event FluxEvent, cluster, component string) pitcher.K8s
 		Namespace: event.InvolvedObject.Namespace,
 		Name:      event.InvolvedObject.Name,
 		Summary:   summary,
-		Severity:  strings.ToUpper(event.Severity),
+		Severity:  fluxSeverityToOutcome(event.Severity),
+		Subsystem: "flux",
 		Timestamp: ts,
 		Cluster:   cluster,
+	}
+}
+
+// fluxSeverityToOutcome maps Flux notification severity to outcome-based severity.
+// Flux sends "info" for successful reconciliations and "error" for failures.
+func fluxSeverityToOutcome(fluxSeverity string) string {
+	switch strings.ToLower(fluxSeverity) {
+	case "info":
+		return "SUCCESS"
+	case "error":
+		return "ERROR"
+	default:
+		return strings.ToUpper(fluxSeverity)
 	}
 }
 

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -95,8 +95,11 @@ func TestHandleFlux(t *testing.T) {
 	if !strings.Contains(got.Summary, "kustomize-controller") {
 		t.Errorf("summary should contain controller, got %q", got.Summary)
 	}
-	if got.Severity != "INFO" {
-		t.Errorf("expected Severity 'INFO', got %q", got.Severity)
+	if got.Severity != "SUCCESS" {
+		t.Errorf("expected Severity 'SUCCESS', got %q", got.Severity)
+	}
+	if got.Subsystem != "flux" {
+		t.Errorf("expected Subsystem 'flux', got %q", got.Subsystem)
 	}
 }
 
@@ -129,7 +132,10 @@ func TestHandleFlux_SeverityPassthrough(t *testing.T) {
 
 	got := mock.lastEvent()
 	if got.Severity != "ERROR" {
-		t.Errorf("expected Severity 'ERROR' (uppercased from Flux event), got %q", got.Severity)
+		t.Errorf("expected Severity 'ERROR' (mapped from Flux 'error'), got %q", got.Severity)
+	}
+	if got.Subsystem != "flux" {
+		t.Errorf("expected Subsystem 'flux', got %q", got.Subsystem)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Severity now reflects **outcome** (`SUCCESS`, `ERROR`, `WARNING`, `INFO`) instead of log levels
- `system` field now contains the source **subsystem** (`flux`, `kubernetes`) instead of cluster name
- `author` field now includes cluster name: `k8s-pitcher-<clustername>` (e.g. `k8s-pitcher-movie-scripts`)
- Flux severity mapping: `info` → `SUCCESS`, `error` → `ERROR`
- K8s event mapping: `add`/`update` → `SUCCESS`, `delete` → `WARNING`, `snapshot` → `INFO`

Closes #38
Closes #39

## Test plan
- [x] All existing tests updated and passing (`go test ./...`)
- [ ] Deploy to test cluster, verify Flux reconciliation events show `severity: SUCCESS`, `system: flux`, `author: k8s-pitcher-<cluster>`
- [ ] Verify K8s informer events show `severity: SUCCESS` for add/update, `system: kubernetes`
- [ ] Check homerun2-scout analytics grouping works with new field values

🤖 Generated with [Claude Code](https://claude.com/claude-code)